### PR TITLE
Disable bitcode for non-Release builds

### DIFF
--- a/Project/Debug.xcconfig
+++ b/Project/Debug.xcconfig
@@ -9,6 +9,9 @@
 // Without dSYM speeds up development iteration
 DEBUG_INFORMATION_FORMAT = dwarf
 
+// Disable bitcode for faster compilation
+ENABLE_BITCODE = NO
+
 // Whether to enable NSAssert
 ENABLE_NS_ASSERTIONS = YES
 

--- a/Project/Release.xcconfig
+++ b/Project/Release.xcconfig
@@ -8,6 +8,10 @@
 // The format of debugging symbols
 DEBUG_INFORMATION_FORMAT = dwarf-with-dsym
 
+// Bitcode isn't supported on all platforms currently
+ENABLE_BITCODE = YES
+ENABLE_BITCODE[sdk=macosx*] = NO
+
 // Whether to enable NSAssert
 ENABLE_NS_ASSERTIONS = NO
 

--- a/Project/Test.xcconfig
+++ b/Project/Test.xcconfig
@@ -11,6 +11,9 @@
 // Allow running unit tests
 ENABLE_TESTABILITY = YES
 
+// Disable bitcode for faster compilation
+ENABLE_BITCODE = NO
+
 // Whether to only build the active architecture
 ONLY_ACTIVE_ARCH = YES
 

--- a/Target/Universal/Framework.Universal.xcconfig
+++ b/Target/Universal/Framework.Universal.xcconfig
@@ -15,10 +15,6 @@ LD_RUNPATH_SEARCH_PATHS[sdk=iphone*] = $(inherited) '@executable_path/Frameworks
 LD_RUNPATH_SEARCH_PATHS[sdk=appletv*] = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
 LD_RUNPATH_SEARCH_PATHS[sdk=watch*] = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
 
-// Bitcode isn't supported on all platforms currently
-ENABLE_BITCODE = YES
-ENABLE_BITCODE[sdk=macosx*] = NO
-
 
 // OSX-specific default settings
 FRAMEWORK_VERSION[sdk=macosx*] = A


### PR DESCRIPTION
Bitcode generation is slow, so only do it when we are releasing.